### PR TITLE
Fix type on CreateChannel code example

### DIFF
--- a/src/tl/channels/CreateChannel.md
+++ b/src/tl/channels/CreateChannel.md
@@ -49,7 +49,7 @@ const client = new TelegramClient(session, apiId, apiHash, {});
 (async function run() {
   await client.connect(); // This assumes you have already authenticated with .start()
 
-  const result: Api.Updates = await client.invoke(
+  const result: Api.TypeUpdates = await client.invoke(
     new Api.channels.CreateChannel({
       title: "My very normal title",
       about: "some string here",


### PR DESCRIPTION
Just got an error after following [this typescript code](https://gram.js.org/tl/channels/CreateChannel)

_Type 'TypeUpdates' is not assignable to type 'Updates'._

I think `Api.TypeUpdates` is more appropriate